### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
   <em>Your AI-powered Epic Planning Assistant for Cursor AI</em>
 </p>
 
+<a href="https://glama.ai/mcp/servers/@RyanCardin15/IntelliPlan-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@RyanCardin15/IntelliPlan-MCP/badge" alt="IntelliPlan MCP server" />
+</a>
+
 ![IntelliPlan MCP Demo](IntelliPlanMCP_Demo.gif)
 
 ---


### PR DESCRIPTION
This PR adds a badge for the [IntelliPlan](https://glama.ai/mcp/servers/@RyanCardin15/IntelliPlan-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@RyanCardin15/IntelliPlan-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@RyanCardin15/IntelliPlan-MCP/badge" alt="IntelliPlan MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.